### PR TITLE
support ASM

### DIFF
--- a/conf.d/fluentd/ASM_conf/ASM_20000_tcp_csv.conf.bak
+++ b/conf.d/fluentd/ASM_conf/ASM_20000_tcp_csv.conf.bak
@@ -1,0 +1,18 @@
+<source>
+  @type tcp
+  tag tcp_input
+  port 20000
+
+  # notice that @log_level needs to be error, 
+  # so that unmatched items will not generate warning logs in td-agent.log
+  @log_level debug
+
+  <parse>
+    @type csv
+    delimiter ",,,"
+    parser_type fast
+    keys blocking_exception_reason,attack_type,captcha_result,client_type,date_time,dest_ip,dest_port,device_id,geo_location,http_class_name,ip_addrewss_intelligence,ip_client,ip_with_route_domain,is_truncated,login_result,management_ip_address,method,mobile_application_name,mobile_application_version,policy_apply_date,policy_name,protocol,query_string,request,request_status,response,response_code,route_domain,session_id,severity,sig_ids,sig_names,sig_set_names,src_port,staged_sig_ids,staged_sig_names,staged_sig_set_names,sub_violations,suppoet_id,unit_hostname,uri,username,violation_rating,violations,virus_name,websocket_direction,websocket_message_type,x_forwarded_for_header_value
+  </parse>
+
+  @label @KAFKA
+</source>

--- a/conf.d/fluentd/ASM_conf/ASM_20000_tcp_regex.conf.bak
+++ b/conf.d/fluentd/ASM_conf/ASM_20000_tcp_regex.conf.bak
@@ -1,0 +1,16 @@
+<source>
+  @type tcp
+  tag tcp_input
+  port 20000
+
+  # notice that @log_level needs to be error, 
+  # so that unmatched items will not generate warning logs in td-agent.log
+  @log_level debug
+
+  <parse>
+    @type regexp
+    expression /^[^:]*:[^:]*:[^:]*:"(?<attack_type>.*)","(?<blocking_exception_reason>.*)","(?<captcha_result>.*)","(?<client_type>.*)","(?<date_time>.*)","(?<dest_ip>.*)","(?<dest_port>.*)","(?<device_id>.*)","(?<geo_location>.*)","(?<http_clas_name>.*)","(?<ip_addrewss_intelligence>.*)","(?<ip_client>.*)","(?<ip_with_route_domain>.*)","(?<is_truncated>.*)","(?<login_result>.*)","(?<management_ip_address>.*)","(?<method>.*)","(?<mobile_application_name>.*)","(?<mobile_application_version>.*)","(?<policy_apply_date>.*)","(?<policy_name>.*)","(?<protocol>.*)","(?<query_string>.*)","(?<request>.*)","(?<request_status>.*)","(?<response>.*)","(?<response_code>.*)","(?<route_domain>.*)","(?<session_id>.*)","(?<severity>.*)","(?<sig_ids>.*)","(?<sig_names>.*)","(?<sig_set_names>.*)","(?<src_port>.*)","(?<staged_sig_ids>.*)","(?<staged_sig_names>.*)","(?<staged_sig_set_names>.*)","(?<sub_violations>.*)","(?<suppoet_id>.*)","(?<unit_hostname>.*)","(?<uri>.*)","(?<username>.*)","(?<violation_details>.*)","(?<violation_rating>.*)","(?<violations>.*)","(?<virus_name>.*)","(?<websocket_direction>.*)","(?<websocket_message_type>.*)","(?<x_forwarded_for_header_value>.*)".*$/
+  </parse>
+
+  @label @DEBUG
+</source>

--- a/conf.d/kibana-exports/7d511000-c696-11ea-8411-6d8833c86f0f.json
+++ b/conf.d/kibana-exports/7d511000-c696-11ea-8411-6d8833c86f0f.json
@@ -1,0 +1,353 @@
+{
+  "version": "7.4.1", 
+  "objects": [
+    {
+      "updated_at": "2020-07-16T02:45:45.585Z", 
+      "version": "WzY4LDFd", 
+      "references": [
+        {
+          "type": "visualization", 
+          "name": "panel_0", 
+          "id": "285f6440-c6b2-11ea-8411-6d8833c86f0f"
+        }, 
+        {
+          "type": "visualization", 
+          "name": "panel_1", 
+          "id": "f2a21bd0-c6b2-11ea-8411-6d8833c86f0f"
+        }, 
+        {
+          "type": "visualization", 
+          "name": "panel_2", 
+          "id": "e669def0-c69b-11ea-8411-6d8833c86f0f"
+        }, 
+        {
+          "type": "visualization", 
+          "name": "panel_3", 
+          "id": "4da4a8a0-c6ad-11ea-8411-6d8833c86f0f"
+        }, 
+        {
+          "type": "visualization", 
+          "name": "panel_4", 
+          "id": "dec6d510-c699-11ea-8411-6d8833c86f0f"
+        }, 
+        {
+          "type": "visualization", 
+          "name": "panel_5", 
+          "id": "1a33e0e0-c6b1-11ea-8411-6d8833c86f0f"
+        }, 
+        {
+          "type": "visualization", 
+          "name": "panel_6", 
+          "id": "b34c0410-c69d-11ea-8411-6d8833c86f0f"
+        }, 
+        {
+          "type": "visualization", 
+          "name": "panel_7", 
+          "id": "d108d2d0-c693-11ea-8411-6d8833c86f0f"
+        }, 
+        {
+          "type": "visualization", 
+          "name": "panel_8", 
+          "id": "9ff9dbf0-c6af-11ea-8411-6d8833c86f0f"
+        }, 
+        {
+          "type": "visualization", 
+          "name": "panel_9", 
+          "id": "c36c0d00-c6b5-11ea-8411-6d8833c86f0f"
+        }, 
+        {
+          "type": "visualization", 
+          "name": "panel_10", 
+          "id": "9ff9dbf0-c6af-11ea-8411-6d8833c86f0f"
+        }, 
+        {
+          "type": "visualization", 
+          "name": "panel_11", 
+          "id": "732d4bb0-c6b5-11ea-8411-6d8833c86f0f"
+        }
+      ], 
+      "migrationVersion": {
+        "dashboard": "7.3.0"
+      }, 
+      "attributes": {
+        "hits": 0, 
+        "timeRestore": false, 
+        "description": "", 
+        "title": "das.ASM", 
+        "panelsJSON": "[{\"embeddableConfig\":{},\"gridData\":{\"h\":14,\"i\":\"b38890f8-8a41-4b75-9d45-06361c6d57d7\",\"w\":12,\"x\":0,\"y\":0},\"panelIndex\":\"b38890f8-8a41-4b75-9d45-06361c6d57d7\",\"version\":\"7.4.1\",\"panelRefName\":\"panel_0\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":15,\"i\":\"e7f9de7a-a684-41c1-9bb5-45c9ec4dc1c5\",\"w\":12,\"x\":12,\"y\":14},\"panelIndex\":\"e7f9de7a-a684-41c1-9bb5-45c9ec4dc1c5\",\"version\":\"7.4.1\",\"panelRefName\":\"panel_1\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":14,\"i\":\"c37d7892-d794-4699-b9f7-bb545ae3b349\",\"w\":12,\"x\":24,\"y\":0},\"panelIndex\":\"c37d7892-d794-4699-b9f7-bb545ae3b349\",\"version\":\"7.4.1\",\"panelRefName\":\"panel_2\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":14,\"i\":\"2ff1e855-f30c-4f63-9d58-5a514e20c409\",\"w\":12,\"x\":36,\"y\":0},\"panelIndex\":\"2ff1e855-f30c-4f63-9d58-5a514e20c409\",\"version\":\"7.4.1\",\"panelRefName\":\"panel_3\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":14,\"i\":\"86ee5183-7b27-4dd0-8b31-5dd23b390326\",\"w\":12,\"x\":12,\"y\":0},\"panelIndex\":\"86ee5183-7b27-4dd0-8b31-5dd23b390326\",\"version\":\"7.4.1\",\"panelRefName\":\"panel_4\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":7,\"i\":\"9f64273b-40ef-41c8-b4a4-0836f73170bd\",\"w\":24,\"x\":24,\"y\":14},\"panelIndex\":\"9f64273b-40ef-41c8-b4a4-0836f73170bd\",\"version\":\"7.4.1\",\"panelRefName\":\"panel_5\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":8,\"i\":\"9d7b500c-b394-4125-b7e1-b6914b26e1d8\",\"w\":24,\"x\":24,\"y\":21},\"panelIndex\":\"9d7b500c-b394-4125-b7e1-b6914b26e1d8\",\"version\":\"7.4.1\",\"panelRefName\":\"panel_6\"},{\"embeddableConfig\":{},\"gridData\":{\"h\":15,\"i\":\"4a66ac73-edd4-44db-aa55-94e7c58035dd\",\"w\":12,\"x\":0,\"y\":14},\"panelIndex\":\"4a66ac73-edd4-44db-aa55-94e7c58035dd\",\"version\":\"7.4.1\",\"panelRefName\":\"panel_7\"},{\"embeddableConfig\":{\"timeRange\":{\"from\":\"now-1h\",\"to\":\"now\"}},\"gridData\":{\"h\":13,\"i\":\"096452dc-a6d2-4cd2-abb0-de5cee6340a8\",\"w\":24,\"x\":24,\"y\":29},\"panelIndex\":\"096452dc-a6d2-4cd2-abb0-de5cee6340a8\",\"version\":\"7.4.1\",\"panelRefName\":\"panel_8\"},{\"embeddableConfig\":{\"colors\":{\"\":\"#7EB26D\"},\"vis\":{\"colors\":{\"\":\"#7EB26D\",\"Cross Site Scripting (XSS)\":\"#962D82\"}}},\"gridData\":{\"h\":15,\"i\":\"1dc8c102-3aae-485e-995a-685b87a3ce7b\",\"w\":24,\"x\":24,\"y\":42},\"panelIndex\":\"1dc8c102-3aae-485e-995a-685b87a3ce7b\",\"version\":\"7.4.1\",\"panelRefName\":\"panel_9\"},{\"embeddableConfig\":{\"timeRange\":{\"from\":\"now-24h\",\"to\":\"now\"}},\"gridData\":{\"h\":13,\"i\":\"3abd227d-6224-437b-8982-7f7abbbc6d5e\",\"w\":24,\"x\":0,\"y\":29},\"panelIndex\":\"3abd227d-6224-437b-8982-7f7abbbc6d5e\",\"version\":\"7.4.1\",\"panelRefName\":\"panel_10\"},{\"embeddableConfig\":{\"colors\":{\"\":\"#7EB26D\",\"Cross Site Scripting (XSS)\":\"#D683CE\"},\"vis\":{\"colors\":{\"\":\"#7EB26D\",\"Cross Site Scripting (XSS)\":\"#962D82\"}}},\"gridData\":{\"h\":15,\"i\":\"4a5d1242-ac1b-495c-a02f-8bb1baa167ad\",\"w\":24,\"x\":0,\"y\":42},\"panelIndex\":\"4a5d1242-ac1b-495c-a02f-8bb1baa167ad\",\"version\":\"7.4.1\",\"panelRefName\":\"panel_11\"}]", 
+        "optionsJSON": "{\"hidePanelTitles\":false,\"useMargins\":true}", 
+        "version": 1, 
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[]}"
+        }
+      }, 
+      "type": "dashboard", 
+      "id": "7d511000-c696-11ea-8411-6d8833c86f0f"
+    }, 
+    {
+      "updated_at": "2020-07-16T03:09:04.367Z", 
+      "version": "WzExMCwxXQ==", 
+      "references": [], 
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      }, 
+      "attributes": {
+        "visState": "{\"title\":\"vis.\u6b63\u5e38\u8bbf\u95ee\u7edf\u8ba1\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"metric\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"filter\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"count\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Normal\",\"filter\":{\"query\":\"violation_rating : 0\",\"language\":\"kuery\"}}],\"time_field\":\"\",\"index_pattern\":\"\",\"interval\":\"\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"general-*\",\"default_timefield\":\"timestamp\",\"isModelInvalid\":false,\"background_color_rules\":[{\"value\":0,\"id\":\"d4540a90-c6b1-11ea-a7bf-657d5f0b627a\",\"color\":\"rgba(104,188,0,1)\",\"operator\":\"gt\"}],\"filter\":{\"query\":\"\",\"language\":\"kuery\"},\"time_range_mode\":\"entire_time_range\"},\"aggs\":[]}", 
+        "description": "", 
+        "title": "vis.\u6b63\u5e38\u8bbf\u95ee\u7edf\u8ba1", 
+        "uiStateJSON": "{}", 
+        "version": 1, 
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+        }
+      }, 
+      "type": "visualization", 
+      "id": "285f6440-c6b2-11ea-8411-6d8833c86f0f"
+    }, 
+    {
+      "updated_at": "2020-07-16T02:45:45.585Z", 
+      "version": "WzcwLDFd", 
+      "references": [
+        {
+          "type": "index-pattern", 
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index", 
+          "id": "5946d770-799e-11ea-b969-3f755ff4e6d6"
+        }
+      ], 
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      }, 
+      "attributes": {
+        "visState": "{\"title\":\"vis.\u4e0d\u540c\u653b\u51fb\u7c7b\u578b\u997c\u72b6\u56fe\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100},\"dimensions\":{\"metric\":{\"accessor\":1,\"format\":{\"id\":\"number\"},\"params\":{},\"aggType\":\"count\"},\"buckets\":[{\"accessor\":0,\"format\":{},\"params\":{},\"aggType\":\"filters\"}]}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"filters\",\"schema\":\"segment\",\"params\":{\"filters\":[{\"input\":{\"query\":\"attack_type.keyword : \\\"SQL-Injection\\\" \",\"language\":\"kuery\"},\"label\":\"SQL-Injection\"},{\"input\":{\"query\":\"attack_type.keyword : \\\"Cross Site Scripting (XSS)\\\" \",\"language\":\"kuery\"},\"label\":\"XSS\"}]}}]}", 
+        "description": "", 
+        "title": "vis.\u4e0d\u540c\u653b\u51fb\u7c7b\u578b\u997c\u72b6\u56fe", 
+        "uiStateJSON": "{}", 
+        "version": 1, 
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      }, 
+      "type": "visualization", 
+      "id": "f2a21bd0-c6b2-11ea-8411-6d8833c86f0f"
+    }, 
+    {
+      "updated_at": "2020-07-16T03:31:34.326Z", 
+      "version": "WzExNSwxXQ==", 
+      "references": [], 
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      }, 
+      "attributes": {
+        "visState": "{\"title\":\"vis.\u653b\u51fb\u8005IP\u7edf\u8ba1\u8868\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"table\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"count\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"color_rules\":[{\"value\":0,\"id\":\"a87514d0-c69a-11ea-9ed8-23da32a2cc08\",\"text\":\"rgba(211,49,21,1)\",\"operator\":\"gt\"}],\"label\":\"count\",\"offset_time\":\"\",\"value_template\":\"\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"general-*\",\"interval\":\"\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"general-*\",\"default_timefield\":\"timestamp\",\"isModelInvalid\":false,\"bar_color_rules\":[{\"id\":\"41ccde70-c69a-11ea-9ed8-23da32a2cc08\"}],\"gauge_color_rules\":[{\"id\":\"46e30dd0-c69a-11ea-9ed8-23da32a2cc08\"}],\"gauge_width\":10,\"gauge_inner_width\":10,\"gauge_style\":\"half\",\"background_color_rules\":[{\"id\":\"47f7d930-c69a-11ea-9ed8-23da32a2cc08\"}],\"pivot_id\":\"ip_client\",\"pivot_type\":\"ip\",\"time_range_mode\":\"entire_time_range\",\"filter\":{\"query\":\"violation_rating > 0\",\"language\":\"kuery\"},\"pivot_label\":\"Attcker ip\"},\"aggs\":[]}", 
+        "description": "", 
+        "title": "vis.\u653b\u51fb\u8005IP\u7edf\u8ba1\u8868", 
+        "uiStateJSON": "{}", 
+        "version": 1, 
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+        }
+      }, 
+      "type": "visualization", 
+      "id": "e669def0-c69b-11ea-8411-6d8833c86f0f"
+    }, 
+    {
+      "updated_at": "2020-07-16T02:45:45.585Z", 
+      "version": "WzcyLDFd", 
+      "references": [], 
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      }, 
+      "attributes": {
+        "visState": "{\"title\":\"vis.\u53d7\u653b\u51fbIP\u7edf\u8ba1\u8868\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"table\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"everything\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"count\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"color_rules\":[{\"value\":0,\"id\":\"166d11b0-c6ad-11ea-b52f-b9efd9d3e7cb\",\"text\":\"rgba(244,78,59,1)\",\"operator\":\"gt\"}],\"filter\":{\"query\":\"\",\"language\":\"kuery\"},\"offset_time\":\"\",\"value_template\":\"\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"general-*\",\"interval\":\"\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"general-*\",\"default_timefield\":\"timestamp\",\"isModelInvalid\":false,\"bar_color_rules\":[{\"id\":\"92d63d90-c6ac-11ea-b52f-b9efd9d3e7cb\"}],\"pivot_id\":\"dest_ip\",\"pivot_type\":\"ip\",\"pivot_label\":\"Victim\",\"time_range_mode\":\"entire_time_range\",\"filter\":{\"query\":\"violation_rating > 0\",\"language\":\"kuery\"}},\"aggs\":[]}", 
+        "description": "", 
+        "title": "vis.\u53d7\u653b\u51fbIP\u7edf\u8ba1\u8868", 
+        "uiStateJSON": "{}", 
+        "version": 1, 
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+        }
+      }, 
+      "type": "visualization", 
+      "id": "4da4a8a0-c6ad-11ea-8411-6d8833c86f0f"
+    }, 
+    {
+      "updated_at": "2020-07-16T02:45:45.585Z", 
+      "version": "WzczLDFd", 
+      "references": [], 
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      }, 
+      "attributes": {
+        "visState": "{\"title\":\"vis.\u653b\u51fb\u6570\u91cf\u7edf\u8ba1\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"metric\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"filter\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"count\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"filter\":{\"query\":\"violation_rating > 0\",\"language\":\"kuery\"},\"label\":\"Attack\"}],\"time_field\":\"@timestamp\",\"index_pattern\":\"general-*\",\"interval\":\"1d\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"general-*\",\"default_timefield\":\"timestamp\",\"isModelInvalid\":false,\"background_color_rules\":[{\"value\":0,\"id\":\"6afccdb0-c699-11ea-9ed8-23da32a2cc08\",\"color\":\"rgba(211,49,21,1)\",\"operator\":\"gt\"}],\"time_range_mode\":\"entire_time_range\",\"filter\":{\"query\":\"\",\"language\":\"kuery\"}},\"aggs\":[]}", 
+        "description": "", 
+        "title": "vis.\u653b\u51fb\u6570\u91cf\u7edf\u8ba1", 
+        "uiStateJSON": "{}", 
+        "version": 1, 
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+        }
+      }, 
+      "type": "visualization", 
+      "id": "dec6d510-c699-11ea-8411-6d8833c86f0f"
+    }, 
+    {
+      "updated_at": "2020-07-16T02:45:45.585Z", 
+      "version": "Wzc0LDFd", 
+      "references": [], 
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      }, 
+      "attributes": {
+        "visState": "{\"title\":\"vis.\u6309\u653b\u51fb\u7c7b\u578b\u7edf\u8ba1Top N\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"top_n\",\"series\":[{\"id\":\"b302cb70-c6b0-11ea-a7bf-657d5f0b627a\",\"color\":\"#68BC00\",\"split_mode\":\"filter\",\"metrics\":[{\"id\":\"b302cb71-c6b0-11ea-a7bf-657d5f0b627a\",\"type\":\"count\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"Normal\",\"filter\":{\"query\":\"attack_type.keyword : \\\"\\\" \",\"language\":\"kuery\"}},{\"id\":\"8e150f30-c6b0-11ea-a7bf-657d5f0b627a\",\"color\":\"rgba(159,5,0,1)\",\"split_mode\":\"filter\",\"metrics\":[{\"id\":\"8e150f31-c6b0-11ea-a7bf-657d5f0b627a\",\"type\":\"count\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"label\":\"SQL-Injection\",\"filter\":{\"query\":\"attack_type.keyword :\\\"SQL-Injection\\\" \",\"language\":\"kuery\"}},{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"rgba(244,78,59,1)\",\"split_mode\":\"filter\",\"metrics\":[{\"id\":\"77b49ad0-c6b0-11ea-a7bf-657d5f0b627a\",\"type\":\"count\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"filter\":{\"query\":\"attack_type.keyword : \\\"Cross Site Scripting (XSS)\\\" \",\"language\":\"kuery\"},\"label\":\"XSS\"}],\"time_field\":\"\",\"index_pattern\":\"\",\"interval\":\"\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"general-*\",\"default_timefield\":\"timestamp\",\"isModelInvalid\":false,\"bar_color_rules\":[{\"id\":\"5864b480-c6b0-11ea-a7bf-657d5f0b627a\"}],\"time_range_mode\":\"entire_time_range\"},\"aggs\":[]}", 
+        "description": "", 
+        "title": "vis.\u6309\u653b\u51fb\u7c7b\u578b\u7edf\u8ba1Top N", 
+        "uiStateJSON": "{}", 
+        "version": 1, 
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+        }
+      }, 
+      "type": "visualization", 
+      "id": "1a33e0e0-c6b1-11ea-8411-6d8833c86f0f"
+    }, 
+    {
+      "updated_at": "2020-07-16T02:45:45.585Z", 
+      "version": "Wzc1LDFd", 
+      "references": [
+        {
+          "type": "index-pattern", 
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index", 
+          "id": "5946d770-799e-11ea-b969-3f755ff4e6d6"
+        }
+      ], 
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      }, 
+      "attributes": {
+        "visState": "{\"title\":\"vis.\u6309\u653b\u51fb\u7c7b\u578b\u7684\u6570\u91cf\u7edf\u8ba1\u67f1\u72b6\u56fe\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"filter\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"BottomAxis-1\",\"type\":\"value\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"normal\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false,\"labels\":{\"show\":false},\"thresholdLine\":{\"show\":false,\"value\":10,\"width\":1,\"style\":\"full\",\"color\":\"#34130C\"},\"dimensions\":{\"x\":{\"accessor\":0,\"format\":{\"id\":\"terms\",\"params\":{\"id\":\"string\",\"otherBucketLabel\":\"Other\",\"missingBucketLabel\":\"Missing\"}},\"params\":{},\"aggType\":\"terms\"},\"y\":[{\"accessor\":1,\"format\":{\"id\":\"number\"},\"params\":{},\"aggType\":\"count\"}]}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"attack_type.keyword\",\"orderBy\":\"1\",\"order\":\"desc\",\"size\":100,\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":true,\"missingBucketLabel\":\"Missing\",\"exclude\":\"\\\"\\\"\"}}]}", 
+        "description": "", 
+        "title": "vis.\u6309\u653b\u51fb\u7c7b\u578b\u7684\u6570\u91cf\u7edf\u8ba1\u67f1\u72b6\u56fe", 
+        "uiStateJSON": "{\"vis\":{\"colors\":{\"Count\":\"#E24D42\"}}}", 
+        "version": 1, 
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      }, 
+      "type": "visualization", 
+      "id": "b34c0410-c69d-11ea-8411-6d8833c86f0f"
+    }, 
+    {
+      "updated_at": "2020-07-16T02:45:45.585Z", 
+      "version": "Wzc2LDFd", 
+      "references": [
+        {
+          "type": "index-pattern", 
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index", 
+          "id": "5946d770-799e-11ea-b969-3f755ff4e6d6"
+        }
+      ], 
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      }, 
+      "attributes": {
+        "visState": "{\"title\":\"vis.\u4e0d\u540c\u7ea7\u522b\u653b\u51fb\u5206\u5e03\u997c\u72b6\u56fe\",\"type\":\"pie\",\"params\":{\"type\":\"pie\",\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"isDonut\":true,\"labels\":{\"show\":false,\"values\":true,\"last_level\":true,\"truncate\":100},\"dimensions\":{\"metric\":{\"accessor\":1,\"format\":{\"id\":\"number\"},\"params\":{},\"aggType\":\"count\"},\"buckets\":[{\"accessor\":0,\"format\":{},\"params\":{},\"aggType\":\"filters\"}]}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"filters\",\"schema\":\"segment\",\"params\":{\"filters\":[{\"input\":{\"query\":\"violation_rating : 3\",\"language\":\"kuery\"},\"label\":\"\"},{\"input\":{\"query\":\"violation_rating : 4\",\"language\":\"kuery\"},\"label\":\"\"}]}}]}", 
+        "description": "", 
+        "title": "vis.\u4e0d\u540c\u7ea7\u522b\u653b\u51fb\u5206\u5e03\u997c\u72b6\u56fe", 
+        "uiStateJSON": "{\"vis\":{\"colors\":{\"violation_rating : 3\":\"#BF1B00\",\"violation_rating : 4\":\"#962D82\"}}}", 
+        "version": 1, 
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"language\":\"kuery\",\"query\":\"\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      }, 
+      "type": "visualization", 
+      "id": "d108d2d0-c693-11ea-8411-6d8833c86f0f"
+    }, 
+    {
+      "updated_at": "2020-07-16T02:45:45.585Z", 
+      "version": "Wzc3LDFd", 
+      "references": [], 
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      }, 
+      "attributes": {
+        "visState": "{\"title\":\"vis.\u653b\u51fb\u6570\u968f\u65f6\u95f4\u5206\u5e03\",\"type\":\"metrics\",\"params\":{\"id\":\"61ca57f0-469d-11e7-af02-69e470af7417\",\"type\":\"timeseries\",\"series\":[{\"id\":\"61ca57f1-469d-11e7-af02-69e470af7417\",\"color\":\"#68BC00\",\"split_mode\":\"filter\",\"metrics\":[{\"id\":\"61ca57f2-469d-11e7-af02-69e470af7417\",\"type\":\"count\"}],\"separate_axis\":0,\"axis_position\":\"right\",\"formatter\":\"number\",\"chart_type\":\"line\",\"line_width\":1,\"point_size\":1,\"fill\":0.5,\"stacked\":\"none\",\"filter\":{\"query\":\"violation_rating > 0\",\"language\":\"kuery\"}}],\"time_field\":\"\",\"index_pattern\":\"\",\"interval\":\"\",\"axis_position\":\"left\",\"axis_formatter\":\"number\",\"axis_scale\":\"normal\",\"show_legend\":1,\"show_grid\":1,\"default_index_pattern\":\"general-*\",\"default_timefield\":\"timestamp\",\"isModelInvalid\":false},\"aggs\":[]}", 
+        "description": "", 
+        "title": "vis.\u653b\u51fb\u6570\u968f\u65f6\u95f4\u5206\u5e03", 
+        "uiStateJSON": "{}", 
+        "version": 1, 
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[]}"
+        }
+      }, 
+      "type": "visualization", 
+      "id": "9ff9dbf0-c6af-11ea-8411-6d8833c86f0f"
+    }, 
+    {
+      "updated_at": "2020-07-16T02:45:45.585Z", 
+      "version": "Wzc4LDFd", 
+      "references": [
+        {
+          "type": "index-pattern", 
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index", 
+          "id": "5946d770-799e-11ea-b969-3f755ff4e6d6"
+        }
+      ], 
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      }, 
+      "attributes": {
+        "visState": "{\"title\":\"vis.\u53d7\u653b\u51fbIP\u88ab\u653b\u51fb\u65b9\u5f0f\u7edf\u8ba1\u67f1\u72b6\u56fe\",\"type\":\"histogram\",\"params\":{\"type\":\"histogram\",\"grid\":{\"categoryLines\":false},\"categoryAxes\":[{\"id\":\"CategoryAxis-1\",\"type\":\"category\",\"position\":\"left\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\"},\"labels\":{\"show\":true,\"filter\":true,\"truncate\":100},\"title\":{}}],\"valueAxes\":[{\"id\":\"ValueAxis-1\",\"name\":\"BottomAxis-1\",\"type\":\"value\",\"position\":\"bottom\",\"show\":true,\"style\":{},\"scale\":{\"type\":\"linear\",\"mode\":\"normal\"},\"labels\":{\"show\":true,\"rotate\":0,\"filter\":false,\"truncate\":100},\"title\":{\"text\":\"Count\"}}],\"seriesParams\":[{\"show\":\"true\",\"type\":\"histogram\",\"mode\":\"stacked\",\"data\":{\"label\":\"Count\",\"id\":\"1\"},\"valueAxis\":\"ValueAxis-1\",\"drawLinesBetweenPoints\":true,\"showCircles\":true}],\"addTooltip\":true,\"addLegend\":true,\"legendPosition\":\"right\",\"times\":[],\"addTimeMarker\":false,\"labels\":{\"show\":false},\"thresholdLine\":{\"show\":false,\"value\":10,\"width\":1,\"style\":\"full\",\"color\":\"#34130C\"},\"dimensions\":{\"x\":{\"accessor\":0,\"format\":{\"id\":\"terms\",\"params\":{\"id\":\"ip\",\"otherBucketLabel\":\"Other\",\"missingBucketLabel\":\"Missing\"}},\"params\":{},\"aggType\":\"terms\"},\"y\":[{\"accessor\":1,\"format\":{\"id\":\"number\"},\"params\":{},\"aggType\":\"count\"}]}},\"aggs\":[{\"id\":\"1\",\"enabled\":true,\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"dest_ip\",\"orderBy\":\"1\",\"order\":\"desc\",\"size\":5,\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}},{\"id\":\"3\",\"enabled\":true,\"type\":\"terms\",\"schema\":\"group\",\"params\":{\"field\":\"attack_type.keyword\",\"orderBy\":\"1\",\"order\":\"desc\",\"size\":5,\"otherBucket\":false,\"otherBucketLabel\":\"Other\",\"missingBucket\":false,\"missingBucketLabel\":\"Missing\"}}]}", 
+        "description": "", 
+        "title": "vis.\u53d7\u653b\u51fbIP\u88ab\u653b\u51fb\u65b9\u5f0f\u7edf\u8ba1\u67f1\u72b6\u56fe", 
+        "uiStateJSON": "{}", 
+        "version": 1, 
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"
+        }
+      }, 
+      "type": "visualization", 
+      "id": "c36c0d00-c6b5-11ea-8411-6d8833c86f0f"
+    }, 
+    {
+      "updated_at": "2020-07-16T03:33:04.340Z", 
+      "version": "WzExNywxXQ==", 
+      "references": [
+        {
+          "type": "index-pattern", 
+          "name": "kibanaSavedObjectMeta.searchSourceJSON.index", 
+          "id": "5946d770-799e-11ea-b969-3f755ff4e6d6"
+        }
+      ], 
+      "migrationVersion": {
+        "visualization": "7.3.1"
+      }, 
+      "attributes": {
+        "visState": "{\n  \"title\": \"vis.\u4e0d\u540cIP\u653b\u51fb\u7c7b\u578b\u7edf\u8ba1\u67f1\u72b6\u56fe\",\n  \"type\": \"histogram\",\n  \"params\": {\n    \"type\": \"histogram\",\n    \"grid\": {\n      \"categoryLines\": false\n    },\n    \"categoryAxes\": [\n      {\n        \"id\": \"CategoryAxis-1\",\n        \"type\": \"category\",\n        \"position\": \"left\",\n        \"show\": true,\n        \"style\": {},\n        \"scale\": {\n          \"type\": \"linear\"\n        },\n        \"labels\": {\n          \"show\": true,\n          \"filter\": true,\n          \"truncate\": 100\n        },\n        \"title\": {}\n      }\n    ],\n    \"valueAxes\": [\n      {\n        \"id\": \"ValueAxis-1\",\n        \"name\": \"BottomAxis-1\",\n        \"type\": \"value\",\n        \"position\": \"bottom\",\n        \"show\": true,\n        \"style\": {},\n        \"scale\": {\n          \"type\": \"linear\",\n          \"mode\": \"normal\"\n        },\n        \"labels\": {\n          \"show\": true,\n          \"rotate\": 0,\n          \"filter\": false,\n          \"truncate\": 100\n        },\n        \"title\": {\n          \"text\": \"Count\"\n        }\n      }\n    ],\n    \"seriesParams\": [\n      {\n        \"show\": \"true\",\n        \"type\": \"histogram\",\n        \"mode\": \"stacked\",\n        \"data\": {\n          \"label\": \"Count\",\n          \"id\": \"1\"\n        },\n        \"valueAxis\": \"ValueAxis-1\",\n        \"drawLinesBetweenPoints\": true,\n        \"showCircles\": true\n      }\n    ],\n    \"addTooltip\": true,\n    \"addLegend\": true,\n    \"legendPosition\": \"right\",\n    \"times\": [],\n    \"addTimeMarker\": false,\n    \"labels\": {\n      \"show\": false\n    },\n    \"thresholdLine\": {\n      \"show\": false,\n      \"value\": 10,\n      \"width\": 1,\n      \"style\": \"full\",\n      \"color\": \"#34130C\"\n    },\n    \"dimensions\": {\n      \"x\": {\n        \"accessor\": 0,\n        \"format\": {\n          \"id\": \"terms\",\n          \"params\": {\n            \"id\": \"string\",\n            \"otherBucketLabel\": \"Other\",\n            \"missingBucketLabel\": \"Missing\"\n          }\n        },\n        \"params\": {},\n        \"aggType\": \"terms\"\n      },\n      \"y\": [\n        {\n          \"accessor\": 2,\n          \"format\": {\n            \"id\": \"number\"\n          },\n          \"params\": {},\n          \"aggType\": \"count\"\n        }\n      ],\n      \"series\": [\n        {\n          \"accessor\": 1,\n          \"format\": {\n            \"id\": \"terms\",\n            \"params\": {\n              \"id\": \"string\",\n              \"otherBucketLabel\": \"Other\",\n              \"missingBucketLabel\": \"Missing\"\n            }\n          },\n          \"params\": {},\n          \"aggType\": \"terms\"\n        }\n      ]\n    }\n  },\n  \"aggs\": [\n    {\n      \"id\": \"1\",\n      \"enabled\": true,\n      \"type\": \"count\",\n      \"schema\": \"metric\",\n      \"params\": {}\n    },\n    {\n      \"id\": \"2\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"segment\",\n      \"params\": {\n        \"field\": \"ip_client\",\n        \"orderBy\": \"1\",\n        \"order\": \"desc\",\n        \"size\": 5,\n        \"otherBucket\": false,\n        \"otherBucketLabel\": \"Other\",\n        \"missingBucket\": false,\n        \"missingBucketLabel\": \"Missing\"\n      }\n    },\n    {\n      \"id\": \"3\",\n      \"enabled\": true,\n      \"type\": \"terms\",\n      \"schema\": \"group\",\n      \"params\": {\n        \"field\": \"attack_type.keyword\",\n        \"orderBy\": \"1\",\n        \"order\": \"desc\",\n        \"size\": 5,\n        \"otherBucket\": false,\n        \"otherBucketLabel\": \"Other\",\n        \"missingBucket\": false,\n        \"missingBucketLabel\": \"Missing\",\n        \"exclude\": \"\",\n        \"customLabel\": \"a\"\n      }\n    }\n  ]\n}", 
+        "description": "", 
+        "title": "vis.\u4e0d\u540cIP\u653b\u51fb\u7c7b\u578b\u7edf\u8ba1\u67f1\u72b6\u56fe", 
+        "uiStateJSON": "{}", 
+        "version": 1, 
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": "{\n  \"query\": {\n    \"query\": \"\",\n    \"language\": \"kuery\"\n  },\n  \"filter\": [],\n  \"indexRefName\": \"kibanaSavedObjectMeta.searchSourceJSON.index\"\n}"
+        }
+      }, 
+      "type": "visualization", 
+      "id": "732d4bb0-c6b5-11ea-8411-6d8833c86f0f"
+    }, 
+    {
+      "updated_at": "2020-07-16T03:07:16.588Z", 
+      "version": "WzEwMiwxXQ==", 
+      "references": [], 
+      "migrationVersion": {
+        "index-pattern": "6.5.0"
+      }, 
+      "attributes": {
+        "fields": "[{\"name\":\"@timestamp\",\"type\":\"date\",\"esTypes\":[\"date\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"_id\",\"type\":\"string\",\"esTypes\":[\"_id\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_index\",\"type\":\"string\",\"esTypes\":[\"_index\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"_score\",\"type\":\"number\",\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_source\",\"type\":\"_source\",\"esTypes\":[\"_source\"],\"count\":0,\"scripted\":false,\"searchable\":false,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"_type\",\"type\":\"string\",\"esTypes\":[\"_type\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":false},{\"name\":\"attack_type\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"attack_type.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"attack_type\",\"subType\":\"multi\"},{\"name\":\"blocking_exception_reason\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"blocking_exception_reason.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"blocking_exception_reason\",\"subType\":\"multi\"},{\"name\":\"captcha_result\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"captcha_result.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"captcha_result\",\"subType\":\"multi\"},{\"name\":\"client_type\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"client_type.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"client_type\",\"subType\":\"multi\"},{\"name\":\"date_time\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"date_time.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"date_time\",\"subType\":\"multi\"},{\"name\":\"dest_ip\",\"type\":\"ip\",\"esTypes\":[\"ip\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"dest_port\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"dest_port.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"dest_port\",\"subType\":\"multi\"},{\"name\":\"device_id\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"device_id.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"device_id\",\"subType\":\"multi\"},{\"name\":\"geo_location\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"geo_location.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"geo_location\",\"subType\":\"multi\"},{\"name\":\"http_class_name\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"http_class_name.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"http_class_name\",\"subType\":\"multi\"},{\"name\":\"ip_addrewss_intelligence\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"ip_addrewss_intelligence.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"ip_addrewss_intelligence\",\"subType\":\"multi\"},{\"name\":\"ip_client\",\"type\":\"ip\",\"esTypes\":[\"ip\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"ip_with_route_domain\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"ip_with_route_domain.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"ip_with_route_domain\",\"subType\":\"multi\"},{\"name\":\"is_truncated\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"is_truncated.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"is_truncated\",\"subType\":\"multi\"},{\"name\":\"login_result\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"login_result.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"login_result\",\"subType\":\"multi\"},{\"name\":\"management_ip_address\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"management_ip_address.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"management_ip_address\",\"subType\":\"multi\"},{\"name\":\"method\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"method.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"method\",\"subType\":\"multi\"},{\"name\":\"mobile_application_name\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"mobile_application_name.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"mobile_application_name\",\"subType\":\"multi\"},{\"name\":\"mobile_application_version\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"mobile_application_version.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"mobile_application_version\",\"subType\":\"multi\"},{\"name\":\"policy_apply_date\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"policy_apply_date.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"policy_apply_date\",\"subType\":\"multi\"},{\"name\":\"policy_name\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"policy_name.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"policy_name\",\"subType\":\"multi\"},{\"name\":\"protocol\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"protocol.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"protocol\",\"subType\":\"multi\"},{\"name\":\"query_string\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"query_string.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"query_string\",\"subType\":\"multi\"},{\"name\":\"request\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"request.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"request\",\"subType\":\"multi\"},{\"name\":\"request_status\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"request_status.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"request_status\",\"subType\":\"multi\"},{\"name\":\"response\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"response.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"response\",\"subType\":\"multi\"},{\"name\":\"response_code\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"response_code.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"response_code\",\"subType\":\"multi\"},{\"name\":\"route_domain\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"route_domain.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"route_domain\",\"subType\":\"multi\"},{\"name\":\"session_id\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"session_id.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"session_id\",\"subType\":\"multi\"},{\"name\":\"severity\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"severity.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"severity\",\"subType\":\"multi\"},{\"name\":\"sig_ids\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"sig_ids.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"sig_ids\",\"subType\":\"multi\"},{\"name\":\"sig_names\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"sig_names.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"sig_names\",\"subType\":\"multi\"},{\"name\":\"sig_set_names\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"sig_set_names.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"sig_set_names\",\"subType\":\"multi\"},{\"name\":\"src_port\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"src_port.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"src_port\",\"subType\":\"multi\"},{\"name\":\"staged_sig_ids\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"staged_sig_ids.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"staged_sig_ids\",\"subType\":\"multi\"},{\"name\":\"staged_sig_names\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"staged_sig_names.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"staged_sig_names\",\"subType\":\"multi\"},{\"name\":\"staged_sig_set_names\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"staged_sig_set_names.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"staged_sig_set_names\",\"subType\":\"multi\"},{\"name\":\"sub_violations\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"sub_violations.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"sub_violations\",\"subType\":\"multi\"},{\"name\":\"suppoet_id\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"suppoet_id.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"suppoet_id\",\"subType\":\"multi\"},{\"name\":\"timestamp\",\"type\":\"date\",\"esTypes\":[\"date\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"type\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"type.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"type\",\"subType\":\"multi\"},{\"name\":\"unit_hostname\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"unit_hostname.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"unit_hostname\",\"subType\":\"multi\"},{\"name\":\"uri\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"uri.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"uri\",\"subType\":\"multi\"},{\"name\":\"username\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"username.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"username\",\"subType\":\"multi\"},{\"name\":\"violation_rating\",\"type\":\"number\",\"esTypes\":[\"long\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true},{\"name\":\"violations\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"violations.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"violations\",\"subType\":\"multi\"},{\"name\":\"virus_name\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"virus_name.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"virus_name\",\"subType\":\"multi\"},{\"name\":\"websocket_direction\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"websocket_direction.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"websocket_direction\",\"subType\":\"multi\"},{\"name\":\"websocket_message_type\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"websocket_message_type.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"websocket_message_type\",\"subType\":\"multi\"},{\"name\":\"x_forwarded_for_header_value\",\"type\":\"string\",\"esTypes\":[\"text\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":false,\"readFromDocValues\":false},{\"name\":\"x_forwarded_for_header_value.keyword\",\"type\":\"string\",\"esTypes\":[\"keyword\"],\"count\":0,\"scripted\":false,\"searchable\":true,\"aggregatable\":true,\"readFromDocValues\":true,\"parent\":\"x_forwarded_for_header_value\",\"subType\":\"multi\"}]", 
+        "timeFieldName": "timestamp", 
+        "title": "general-*"
+      }, 
+      "type": "index-pattern", 
+      "id": "5946d770-799e-11ea-b969-3f755ff4e6d6"
+    }
+  ]
+}

--- a/conf.d/logstash/index-templates/general-template.tmpl
+++ b/conf.d/logstash/index-templates/general-template.tmpl
@@ -19,7 +19,16 @@
       },
       "timestamp": {
         "type": "date"
-      }
+      },
+      "ip_client": {
+        "type": "ip"
+      },
+      "dest_ip": {
+        "type": "ip"
+      },
+      "violation_rating": {
+        "type": "long"
+      }     
     }
   }
 }


### PR DESCRIPTION
1. Fluentd configuration files for receiving ASM log data are in `conf.d/fluentd/ASM_conf/` folder. `ASM_20000_tcp_csv.conf.bak `  is the configuration file being used, but `ASM_20000_tcp_regex.conf.bak` is just for reference.
2. If we want to receive ASM log data, we should rename `ASM_20000_tcp_csv.conf.bak ` to `ASM_20000_tcp_csv.conf ` and move to `conf.d/fluentd/` folder. P.S. In `conf.d/fluentd/` folder, we also need rename the other configuration files in the same port to avoid port conflict.
3. Add some mapping entry for ASM log data in the `general-template`.
4. `conf.d/kibana-exports/7d511000-c696-11ea-8411-6d8833c86f0f.json` is the ASM dashboard data.