### PR TITLE
Fix issue of circuit_breaking_exception

### DIFF
--- a/conf.d/docker-compose.yml
+++ b/conf.d/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     environment:
       - discovery.type=single-node
     volumes:
+      - ${HOMEDIR}/conf.d/elasticsearch/jvm.options:/usr/share/elasticsearch/config/jvm.options
+      - ${HOMEDIR}/conf.d/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
       - ${HOMEDIR}/data/elasticsearch:/usr/share/elasticsearch/data
     networks:
       - ta-net

--- a/conf.d/elasticsearch/elasticsearch.yml
+++ b/conf.d/elasticsearch/elasticsearch.yml
@@ -1,0 +1,6 @@
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
+
+indices.breaker.total.limit: 75%
+indices.breaker.fielddata.limit: 40%
+indices.breaker.request.limit: 75%

--- a/conf.d/elasticsearch/jvm.options
+++ b/conf.d/elasticsearch/jvm.options
@@ -1,0 +1,121 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms1g
+-Xmx4g
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1GC is only supported on JDK version 10 or later.
+# To use G1GC uncomment the lines below.
+# 10-:-XX:-UseConcMarkSweepGC
+# 10-:-XX:-UseCMSInitiatingOccupancyOnly
+# 10-:-XX:+UseG1GC
+# 10-:-XX:G1ReservePercent=25
+# 10-:-XX:InitiatingHeapOccupancyPercent=30
+
+## DNS cache policy
+# cache ttl in seconds for positive DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+-Des.networkaddress.cache.ttl=60
+# cache ttl in seconds for negative DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+# forever
+-Des.networkaddress.cache.negative.ttl=10
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# explicitly set the stack size
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+-Dio.netty.allocator.numDirectArenas=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=data
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=logs/hs_err_pid%p.log
+
+## JDK 8 GC logging
+
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:logs/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+9-:-Djava.locale.providers=COMPAT


### PR DESCRIPTION
by increasing jvm size, allowing customizing indices.breaker.*.limit

issue detail:

FATAL  [circuit_breaking_exception] [parent]
Data too large, data for [<http_request>] would be [1017560880/970.4mb],
which is larger than the limit of [986061209/940.3mb],
real usage: [1017560880/970.4mb],
new bytes reserved: [0/0b],
usages [request=0/0b, fielddata=0/0b, in_flight_requests=0/0b, accounting=88331753/84.2mb],
with { bytes_wanted=1017560880 & bytes_limit=986061209 & durability="PERMANENT" } ::
{
    "path":"/.kibana_task_manager",
    "query":{},
    "statusCode":429,
    "response":"{\"error\":{\"root_cause\":[{\"type\":\"circuit_breaking_exception\",\"reason\":\"[parent] Data too large, data for [<http_request>] would be [1017560880/970.4mb], which is larger than the limit of [986061209/940.3mb], real usage: [1017560880/970.4mb], new bytes reserved: [0/0b], usages [request=0/0b, fielddata=0/0b, in_flight_requests=0/0b, accounting=88331753/84.2mb]\",\"bytes_wanted\":1017560880,\"bytes_limit\":986061209,\"durability\":\"PERMANENT\"}],\"type\":\"circuit_breaking_exception\",\"reason\":\"[parent] Data too large, data for [<http_request>] would be [1017560880/970.4mb], which is larger than the limit of [986061209/940.3mb], real usage: [1017560880/970.4mb], new bytes reserved: [0/0b], usages [request=0/0b, fielddata=0/0b, in_flight_requests=0/0b, accounting=88331753/84.2mb]\",\"bytes_wanted\":1017560880,\"bytes_limit\":986061209,\"durability\":\"PERMANENT\"},\"status\":429}"
}